### PR TITLE
Explicitly include giflib libs/headers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -269,6 +269,8 @@ function build_vips {
     ./configure --prefix $OUT_PATH --enable-shared --disable-static --disable-dependency-tracking \
   --disable-debug --disable-introspection --without-python --without-fftw \
   --without-magick --without-pangoft2 --without-ppm --without-analyze --without-radiance \
+  --with-giflib-includes=$OUT_PATH/include \
+  --with-giflib-libraries=$OUT_PATH/lib
     # Make
     make
     # install vips


### PR DESCRIPTION
After running `build.sh`, it seems giflib installed at prefix (`$OUT_PATH`):

```
vilson@macbook:~/tmp/target/app/vendor/vips$ ls
bin  include  lib  libvips-0.4.0-unknown.tgz  share
vilson@macbook:~/tmp/target/app/vendor/vips$ ls include/
drvrsmem.h  fitsio.h   lcms2.h         libgsf-1   vips
fitsio2.h   gif_lib.h  lcms2_plugin.h  longnam.h  webp
vilson@macbook:~/tmp/target/app/vendor/vips$ ls lib/
libcfitsio.a     libgsf-1.so.114.0.30  libvipsCC.so.42.4.1    libwebp.a
libgif.la        liblcms2.a            libvips-cpp.la         libwebp.la
libgif.so        liblcms2.la           libvips-cpp.so         libwebp.so
libgif.so.7      liblcms2.so           libvips-cpp.so.42      libwebp.so.5
libgif.so.7.0.0  liblcms2.so.2         libvips-cpp.so.42.4.1  libwebp.so.5.0.0
libgsf-1.a       liblcms2.so.2.0.6     libvips.la             pkgconfig
libgsf-1.la      libvipsCC.la          libvips.so
libgsf-1.so      libvipsCC.so          libvips.so.42
libgsf-1.so.114  libvipsCC.so.42       libvips.so.42.4.1
```

So this explicitly includes both paths to libvips `configure`.
